### PR TITLE
Implemented an Override (#5)

### DIFF
--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -172,6 +172,12 @@ class RandoHandler(RaceHandler):
         self.state["locked"] = False
         await self.send_message("Seed rolling is now unlocked.")
 
+    @monitor_cmd
+    async def ex_reset(self, args, message):
+        self.state["permalink"] = None
+        self.state["permalink_available"] = False
+        await self.send_message("The Permalink has been reset.")
+
     async def ex_rollseed(self, args, message):
         if self.state.get("locked") and not can_monitor(message):
             await self.send_message(


### PR DESCRIPTION
* Implemented an Override

In cases where the wrong seed is rolling (Whoops) this would allow a state reset without leaving the race room. This wouldn't work for Spoiler Log seeds, and is locked to Race Monitors.

* Flax Compliant

* Flake*

* Update randobot/handler.py

Co-authored-by: wooferzfg <spapushin@gmail.com>

Co-authored-by: wooferzfg <spapushin@gmail.com>